### PR TITLE
Added statement_counter dictionary to track Value statements received by Nodes

### DIFF
--- a/src/Value.py
+++ b/src/Value.py
@@ -42,6 +42,11 @@ class Value():
     def __eq__(self, other):
         return (self.hash == other.hash and self.state == other.state and set(self.transactions) == set(other.transactions))
 
+
+    def __hash__(self):
+        return hash(self._hash)
+
+
     @property
     def transactions(self):
         return self._transactions


### PR DESCRIPTION
This commit adds a statement_counter dictionary to track the amount of times statements have been received for Values by different nodes. It also adds a function to update and set counts. Unit tests for the functions have been made and duplicate unit tests have been fixed. This data structure and function are key to implement thresholding functionality to advance the states of Values in the Protocol.