### PR TITLE
Feature - Update QuorumSet, added functions to check Quorum & Blocking threshold, 

### DIFF
--- a/src/Network.py
+++ b/src/Network.py
@@ -3,8 +3,8 @@
 Network
 =========================
 
-Author: Matija Piskorec
-Last update: August 2023
+Author: Matija Piskorec, Jaime de Vivero Woods
+Last update: July 2024
 
 Network class. Setup Stellar validator network by initializing nodes and setting their quorum sets based on a predefined topology.
 """
@@ -40,8 +40,9 @@ class Network():
                 # We add all nodes to the quorum set of each node, including the node itself
                 for node in nodes:
                     log.network.debug('Adding nodes %s to the quorum set of Node %s', nodes, node)
-                    node.set_quorum(nodes)
+                    node.set_quorum(nodes, [])
             case 'ER':
+                # Instead of adding all nodes frpm the graph to QuorumSet, we make a distribution so some also go into inner sets
                 graph = nx.fast_gnp_random_graph(n_nodes,0.5) # make a random graph - could include all or only a few, some nodes may have many connections and some few or none
                 lcc_set = max(nx.connected_components(graph), key=len) # LCC is the main node with the most connections
                 missing = list(set(int(node.name) for node in nodes) - lcc_set) # nodes are not included in any quorum set and are considered "missing" in the context of the simulation
@@ -52,10 +53,32 @@ class Network():
                                       missing)
                 for node in nodes:
                     filtered_nodes = [nodes[edge[1]] for edge in graph.edges(int(node.name))]
-                    # Adding the node itself to the set of nodes for the quorum set
-                    filtered_nodes.append(node)
-                    log.network.debug('Adding nodes %s to the quorum set of Node %s',
-                                      filtered_nodes, node)
-                    node.set_quorum(filtered_nodes)
+
+                    if len(filtered_nodes) > 1:
+                        filter_distribution = len(filtered_nodes)//2 # Filter nodes for Quorums as half to Quorum and half to inner sets
+
+                        quorum_distribution = filtered_nodes[:filter_distribution]
+                        inner_quorum_distribution = filtered_nodes[filter_distribution:]
+                        quorum_distribution.append(node)
+                        log.network.debug('Adding nodes %s to the quorum set of Node %s', quorum_distribution, node)
+
+                        if len(inner_quorum_distribution) > 1: # If more than 2 nodes filtered, then define 2 inner sets for the QuorumSet
+                            inner_set_distribution = len(inner_quorum_distribution) // 2 # Stick to only 2 inner sets per node for now
+                            inner_set1 = inner_quorum_distribution[inner_set_distribution:]
+                            inner_set2 = inner_quorum_distribution[:inner_set_distribution]
+                            inner_set1.append(node)
+                            inner_set2.append(node)
+                            log.network.debug('Adding nodes %s to inner set 1, and nodes %s to inner set 2 of Node %s', inner_set1, inner_set2, node)
+                            node.set_quorum(nodes=quorum_distribution, inner_sets=[inner_set1, inner_set2])
+
+                        else: # In the case where only 2 nodes are added to Quorum only one inner set defined
+                            inner_quorum_distribution.append(node)
+                            log.network.debug('Adding nodes %s to the inner set of Node %s', inner_quorum_distribution, node)
+                            node.set_quorum(nodes=quorum_distribution, inner_sets=inner_quorum_distribution)
+
+                    else: # If only one node filtered then make no inner sets
+                        filtered_nodes.append(node)
+                        log.network.debug('Adding nodes %s to the quorum set of Node %s',filtered_nodes, node)
+                        node.set_quorum(filtered_nodes, [])
 
         return nodes

--- a/src/Network_test.py
+++ b/src/Network_test.py
@@ -1,0 +1,27 @@
+from Log import log
+import unittest
+from Network import Network
+
+class NetworkTest(unittest.TestCase):
+    def setup(self):
+        pass
+
+    def test_generate_nodes_ER(self):
+        topology = 'ER'
+        nodes = Network.generate_nodes(n_nodes=5, topology=topology)
+
+        for node in nodes:
+                log.test.debug('Node %s, all peers in quorum set = %s',node.name,node.quorum_set.get_nodes())
+                self.assertTrue(len(node.quorum_set.nodes) >= 1)
+
+                # If 3 nodes are filtered to be added to the current node, 1 should be added to the Quorum and the 2 others should be added as distinct sets
+                if len(node.quorum_set.nodes) > 2:
+                    self.assertTrue(len(node.quorum_set.inner_sets) > 1)
+
+    def test_generate_nodes_FULL(self):
+        topology = 'FULL'
+        nodes = Network.generate_nodes(n_nodes=5, topology=topology)
+
+        for node in nodes:
+                log.test.debug('Node %s, all peers in quorum set = %s',node.name,node.quorum_set.get_nodes())
+                self.assertTrue(len(node.quorum_set.nodes) > 1)

--- a/src/QuorumSet.py
+++ b/src/QuorumSet.py
@@ -94,3 +94,12 @@ class QuorumSet():
             return True
         else:
             return False
+
+    def check_inner_set_blocking_threshold(self, calling_node, val, quorum):
+        # Check if any node in the Quorum has issued message "m" - not including the node itself
+        count = 0
+        for node in quorum:
+            if (node != calling_node) and (node in calling_node.statement_counter[val.hash]["voted"]) or (node != calling_node) and (node in calling_node.statement_counter[val.hash]["accepted"]):
+                count += 1
+
+        return count

--- a/src/QuorumSet.py
+++ b/src/QuorumSet.py
@@ -26,18 +26,13 @@ class QuorumSet():
 
         # Quorum set knows to which node it belongs to
         self.node = node
-
-        # No input nodes should be of different type than Node
-        # TODO: We cannot check for Node instance in QuorumSet class because of circular import!
-        # assert len([not isinstance(node,Node) for node in nodes])<1 # Allows for empty list of nodes!
-
         self.threshold = kvargs['threshold'] if 'threshold' in kvargs else THRESHOLD_DEFAULT
 
-        # TODO: Important otherwise all QuorumSets will share a list of nodes!
         self.nodes = []
+        self.inner_sets = [] # will keep to 1 layer of depth for now, rarely gets deeper
 
         log.quorum.info('Initialized quorum set for Node %s, threshold=%s, nodes=%s.',
-                        self.node, self.threshold, self.nodes)
+                        self.node, self.threshold, self.nodes, self.inner_sets)
 
     def __repr__(self):
         return '[Quorum Set: threshold=%(threshold)s, nodes=%(nodes)s.' % self.__dict__
@@ -50,29 +45,8 @@ class QuorumSet():
         self.nodes = filter(lambda x: x != node, self.nodes)
         return
 
-    # # Add nodes to quorum
-    # # TODO: Consider removing QuorumSet.add() because we are only using QuorumSet.set()!
-    # def add(self, nodes):
-
-    #     # If there is only one node as input, convert it to list so that we can iterate over it
-    #     if type(nodes) is not list:
-    #         nodes = [nodes]
-
-    #     # No input nodes should be of different type than Node
-    #     # TODO: We cannot check for Node instance in QuorumSet class because of circular import!
-    #     # assert len([not isinstance(node,Node) for node in nodes])<1 # Allows for empty list of nodes!
-
-    #     for node in nodes:
-    #         # Only add the node to the quorum set if it isn't already there!
-    #         # Quorum set always contains the node itself, so we allow to add it to the quorum set 
-    #         if (node not in self.nodes):
-    #             self.nodes.append(node)
-    #             log.quorum.info('Added node %s to quorum set of Node %s.', node, self.node)
-
-    #     return
-
     # Set quorum to the nodes
-    def set(self, nodes):
+    def set(self, nodes, inner_sets):
 
         # If there is only one node as input, convert it to list so that we can iterate over it
         if type(nodes) is not list:
@@ -80,6 +54,7 @@ class QuorumSet():
 
         # TODO: Perform duplicate checks while adding nodes to the quorum!
         self.nodes = nodes
+        self.inner_sets = inner_sets if inner_sets is not None else []
 
         log.quorum.info('Set nodes %s as the quorum set of Node %s.', nodes, self.node)
 
@@ -94,8 +69,10 @@ class QuorumSet():
             return np.random.choice([node for node in self.nodes if node != self.node])
 
     def get_nodes(self):
-        # TODO: Should we return self.nodes.copy() instead?
-        return self.nodes
+        return self.nodes.copy()
+
+    def get_inner_sets(self):
+        return self.inner_sets.copy()
 
     # TODO: Check minimum_quorum() method because it looks strange, I don't understand it!
     @property
@@ -103,8 +80,20 @@ class QuorumSet():
         # Minimum number of nodes (round up) required to reach threshold
         return math.ceil((len(self.nodes) + 1) * (self.threshold / 100))
 
-    # TODO: Quorum is constructed by a union of all quorum sets of nodes in the quorum set!
     def get_quorum(self):
-        nodes = set().union(*[node.quorum_set.get_nodes() for node in self.node.quorum_set.get_nodes()])
-        return nodes
+        return self.get_nodes(), self.get_inner_sets()
+
+    def check_threshold(self, val, node_statement_counter):
+        node_counter = 0
+        inner_set_counter = 0
+
+        for node in self.nodes:
+            if node in node_statement_counter[val.hash]["voted"] or node in node_statement_counter[val.hash]["accepted"]:
+                node_counter += 1
+
+        for set in self.inner_sets:
+            for node in set:
+                if node in node_statement_counter[val.hash]["voted"] or node in node_statement_counter[val]["acccepted"]:
+                    inner_set_counter += 1
+
 

--- a/src/QuorumSet_test.py
+++ b/src/QuorumSet_test.py
@@ -1,0 +1,27 @@
+import unittest
+from Value import Value
+from Node import Node
+from Transaction import Transaction
+
+class QuorumSetTest(unittest.TestCase):
+    def setUp(self):
+        self.node = Node("test_node")
+
+    def test_check_threshold(self):
+        test_node1 = Node("test_node1")
+        test_node2 = Node("test_node2")
+        test_node3 = Node("test_node3")
+        test_node4 = Node("test_node4")
+
+        value = Value(transactions={Transaction(0), Transaction(0)})
+        threshold = 4
+        statement_counter = {value.hash: {'voted': {test_node1.name: 1, test_node2.name : 1, test_node3.name: 1}, 'accepted': {test_node4.name : 1}}}
+
+        quorum = [test_node1, test_node2, test_node3, test_node4]
+
+        check = self.node.quorum_set.check_threshold(value, quorum, threshold, statement_counter)
+        self.assertTrue(check)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/QuorumSet_test.py
+++ b/src/QuorumSet_test.py
@@ -22,6 +22,29 @@ class QuorumSetTest(unittest.TestCase):
         check = self.node.quorum_set.check_threshold(value, quorum, threshold, statement_counter)
         self.assertTrue(check)
 
+    def test_inner_set_blocking_threshold_is_met(self):
+        test_node1 = Node("test_node1")
+        test_node2 = Node("test_node2")
+        test_node3 = Node("test_node3")
+
+        value = Value(transactions={Transaction(0), Transaction(0)})
+        test_node1.statement_counter = {value.hash: {'voted': {test_node1.name: 1, test_node2.name : 1}, 'accepted': {test_node3.name: 1}}}
+        quorum = [test_node1, test_node2]
+
+        check = self.node.quorum_set.check_inner_set_blocking_threshold(test_node1, value, quorum)
+        self.assertEqual(check, 1)
+
+    def test_inner_set_blocking_threshold_returns_is_not_met(self):
+        # If only the calling node has voted, then it should return False
+        test_node1 = Node("test_node1")
+
+        value = Value(transactions={Transaction(0), Transaction(0)})
+        test_node1.statement_counter = {value.hash: {'voted': {test_node1.name: 1}, 'accepted': {}}}
+        quorum = [test_node1]
+
+        check = self.node.quorum_set.check_inner_set_blocking_threshold(test_node1, value, quorum)
+        self.assertEqual(check, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/SCPNominate.py
+++ b/src/SCPNominate.py
@@ -4,7 +4,7 @@ SCPNominate
 =========================
 
 Author: Matija Piskorec, Jaime de Vivero Woods
-Last update: May 2024
+Last update: July 2024
 
 SCPNominate message class.
 """
@@ -67,8 +67,8 @@ class SCPNominate(Message):
             voted_values = [value for value in message.voted]
             accepted_values = [value for value in message.accepted]
             if len(accepted_values) == 0:
-                return Value.combine(voted_values), []
+                return [Value.combine(voted_values), []]
             elif len(voted_values) == 0:
-                return [], Value.combine(accepted_values)
+                return [[], Value.combine(accepted_values)]
 
-            return Value.combine(voted_values), Value.combine(accepted_values)
+            return [Value.combine(voted_values), Value.combine(accepted_values)]

--- a/src/SCPNominate_test.py
+++ b/src/SCPNominate_test.py
@@ -5,7 +5,7 @@ from Node import Node
 from Transaction import Transaction
 from SCPNominate import SCPNominate
 
-class StorageTest(unittest.TestCase):
+class SCPNominateTest(unittest.TestCase):
 
     def test_parse_message_state_returns_correctly(self):
         value1 = Value(transactions={Transaction(0), Transaction(0)})

--- a/src/Simulator.py
+++ b/src/Simulator.py
@@ -3,8 +3,8 @@
 Simulator
 ================================================
 
-Author: Matija Piskorec
-Last update: August 2023
+Author: Matija Piskorec, Jaime de Vivero Woods
+Last update: July 2023
 
 The following class contains command line (CLI) interface for the Stellar Consensus Protocol (SCP) simulator.
 
@@ -36,7 +36,7 @@ from Mempool import Mempool
 from Globals import Globals
 
 VERBOSITY_DEFAULT = 5
-N_NODES_DEFAULT = 2
+N_NODES_DEFAULT = 5
 
 class Simulator:
     '''
@@ -87,8 +87,8 @@ class Simulator:
         if self._verbosity:
             log.simulator.debug('Creating %s nodes.', self._n_nodes)
 
-        self._nodes = Network.generate_nodes(n_nodes=self._n_nodes, topology='FULL')
-        # self._nodes = Network.generate_nodes(n_nodes=self._n_nodes, topology='ER')
+        # self._nodes = Network.generate_nodes(n_nodes=self._n_nodes, topology='FULL')
+        self._nodes = Network.generate_nodes(n_nodes=self._n_nodes, topology='ER')
 
         self._mempool = Mempool()
         # self._mempool = Mempool(simulation_time=self._simulation_time)

--- a/src/Storage.py
+++ b/src/Storage.py
@@ -3,8 +3,8 @@
 Storage
 =========================
 
-Author: Matija Piskorec
-Last update: August 2023
+Author: Matija Piskorec, Jaime de Vivero Woods
+Last update: April 2024
 
 Storage class.
 """

--- a/src/Storage_test.py
+++ b/src/Storage_test.py
@@ -14,8 +14,8 @@ class StorageTest(unittest.TestCase):
     def test_empty_messages(self):
         # Test that empty messages return empty Value objects for voted and accepted
         voted, accepted = self.storage.get_combined_messages()
-        self.assertEqual(len(voted.transactions), 0) # Voted field should be empty
-        self.assertEqual(len(accepted.transactions), 0) # Accepted field should be empty
+        self.assertEqual(len(voted), 0) # Voted field should be empty
+        self.assertEqual(len(accepted), 0) # Accepted field should be empty
 
     def test_single_message(self):
         # Test combining a single message


### PR DESCRIPTION
This branch adds functionality to implement inner sets, add checks of Quorum and Blocking threshold & updates relevant Network, Simulator and other classes to implement these changes.

The new Simulator now:
- runs in 'ER 'topology as opposed to 'FULL' 
- If enough nodes are added to Quorum, 2 inner sets are defined (this may have to be expanded with a function that calculates the number of inner sets depending on size, but as of now its a 50/50 split into Quorum +  2 inner sets)
- After receiving a message from its priority node during Nomination, the node checks for Quorum and Blocking threshold 