### PR TITLE
This commit adds the update nomination state feature to Node.py

### DIFF
--- a/src/Node.py
+++ b/src/Node.py
@@ -168,7 +168,7 @@ class Node():
                 voted_val = message[0] # message[0] is voted field
                 if type(voted_val) is Value and self.check_Quorum_threshold(voted_val):
                     log.node.info('Quorum threshold met for value %s at Node %s', voted_val, self.name)
-                    # TODO: Implement update_state function to move val to 'accepted' field in nomination_state
+                    self.update_nomination_state(voted_val)
 
                 if type(voted_val) is Value and self.check_Blocking_threshold(voted_val):
                     log.node.info('Blocking threshold met for value %s at Node %s', voted_val, self.name)
@@ -425,3 +425,17 @@ class Node():
             return (signed_count + inner_set_count) > (n - k)
 
         return False
+
+    def update_nomination_state(self, val):
+        if len(self.nomination_state["voted"]) > 0 :
+            if val in self.nomination_state['accepted']:
+                log.node.info('Value %s is already accepted in Node %s', val, self.name)
+                return
+
+            if val in self.nomination_state['voted']:
+                self.nomination_state['voted'].remove(val)
+
+            self.nomination_state['accepted'].append(val)
+            log.node.info('Value %s has been moved to accepted in Node %s', val, self.name)
+        else:
+            log.node.info('No values in voted state, cannot move Value %s to accepted in Node %s', val, self.name)

--- a/src/Node_test.py
+++ b/src/Node_test.py
@@ -566,3 +566,83 @@ class NodeTest(unittest.TestCase):
 
         result = self.node.check_Blocking_threshold(value)
         self.assertFalse(result)
+
+    def test_update_nomination_state_correctly_updates(self):
+        self.node = Node(name="1")
+
+        value = Value(transactions={Transaction(0), Transaction(0)})
+        value2 = Value(transactions={Transaction(0)})
+        value3 = Value(transactions={Transaction(0)})
+
+        self.node.nomination_state = {
+            "voted": [value, value2],
+            "accepted": [value3],
+            "confirmed": []
+        }
+        self.node.update_nomination_state(value)
+
+        assert all([isinstance(vote, Value) for vote in self.node.nomination_state['voted']])
+        assert all([isinstance(vote, Value) for vote in self.node.nomination_state['accepted']])
+        # The second Value in the state should contain all txs from ledger which should now be 2
+        self.assertTrue(self.node.nomination_state['voted'] == [value2])
+        self.assertTrue(self.node.nomination_state['accepted'] == [value3, value])
+        self.assertTrue(len(self.node.nomination_state['accepted']) == 2)
+
+    def test_update_nomination_state_updates_voted_to_accepted(self):
+        self.node = Node(name="1")
+
+        value = Value(transactions={Transaction(0), Transaction(0)})
+        value2 = Value(transactions={Transaction(0)})
+        value3 = Value(transactions={Transaction(0)})
+
+        self.node.nomination_state = {
+            "voted": [value2],
+            "accepted": [value, value3],
+            "confirmed": []
+        }
+        self.node.update_nomination_state(value)
+
+        assert all([isinstance(vote, Value) for vote in self.node.nomination_state['voted']])
+        assert all([isinstance(vote, Value) for vote in self.node.nomination_state['accepted']])
+        self.assertTrue(self.node.nomination_state['voted'] == [value2])
+        self.assertTrue(self.node.nomination_state['accepted'] == [value, value3])
+        self.assertTrue(len(self.node.nomination_state['accepted']) == 2)
+
+    def test_update_nomination_state_does_not_update_accepted(self):
+        self.node = Node(name="1")
+
+        value = Value(transactions={Transaction(0), Transaction(0)})
+        value2 = Value(transactions={Transaction(0)})
+        value3 = Value(transactions={Transaction(0)})
+
+        self.node.nomination_state = {
+            "voted": [value2],
+            "accepted": [value, value3],
+            "confirmed": []
+        }
+        self.node.update_nomination_state(value)
+
+        assert all([isinstance(vote, Value) for vote in self.node.nomination_state['voted']])
+        assert all([isinstance(vote, Value) for vote in self.node.nomination_state['accepted']])
+        self.assertTrue(self.node.nomination_state['voted'] == [value2])
+        self.assertTrue(self.node.nomination_state['accepted'] == [value, value3])
+        self.assertTrue(len(self.node.nomination_state['accepted']) == 2)
+
+    def test_update_nomination_state_does_not_fail_when_empty(self):
+        self.node = Node(name="1")
+
+        value = Value(transactions={Transaction(0), Transaction(0)})
+        value3 = Value(transactions={Transaction(0)})
+
+        self.node.nomination_state = {
+            "voted": [],
+            "accepted": [value3],
+            "confirmed": []
+        }
+        self.node.update_nomination_state(value)
+
+        assert all([isinstance(vote, Value) for vote in self.node.nomination_state['voted']])
+        assert all([isinstance(vote, Value) for vote in self.node.nomination_state['accepted']])
+        self.assertTrue(self.node.nomination_state['voted'] == [])
+        self.assertTrue(self.node.nomination_state['accepted'] == [value3])
+        self.assertTrue(len(self.node.nomination_state['accepted']) == 1)


### PR DESCRIPTION
This commit adds the update nomination state feature to Node.py
In Node.py:
1. An update_nomination_state() function that moves Values from 'voted' to 'accepted' that is called in receive_message() after Quorum Threshold is met. Unit tests for this function has also been made