### PR TITLE
Added SCPBallot and SCPPrepare

### DIFF
--- a/src/SCPBallot.py
+++ b/src/SCPBallot.py
@@ -1,0 +1,14 @@
+from Value import Value
+
+class SCPBallot:
+    def __init__(self, counter: int, value: Value):
+        self.counter = counter
+        self.value = value
+
+    def __lt__(self, other):
+        if self.counter != other.counter:
+            return self.counter < other.counter
+        return self.value.hash < other.value.hash
+
+    def __repr__(self):
+        return f"SCPBallot(counter={self.counter}, value={self.value})"

--- a/src/SCPBallot_test.py
+++ b/src/SCPBallot_test.py
@@ -1,0 +1,29 @@
+import unittest
+from Transaction import Transaction
+from State import State
+from Value import Value
+from SCPBallot import SCPBallot
+
+class SCPBallot_test(unittest.TestCase):
+    def setUp(self):
+        transactions1 = [Transaction(time=1.0)]
+        transactions2 = [Transaction(time=2.0)]
+        state = State.init
+        self.value1 = Value(transactions=transactions1, state=state)
+        self.value2 = Value(transactions=transactions2, state=state)
+        self.ballot1 = SCPBallot(counter=1, value=self.value1)
+        self.ballot2 = SCPBallot(counter=2, value=self.value2)
+
+    def test_ballot_initialization(self):
+        self.assertEqual(self.ballot1.counter, 1)
+        self.assertEqual(self.ballot1.value, self.value1)
+
+    def test_ballot_comparison(self):
+        self.assertTrue(self.ballot1 < self.ballot2)
+        self.assertFalse(self.ballot2 < self.ballot1)
+        self.assertTrue(self.ballot1 < SCPBallot(counter=2, value=self.value1))
+        self.assertFalse(self.ballot1 < SCPBallot(counter=1, value=self.value2))
+
+    def test_ballot_repr(self):
+        self.assertEqual(repr(self.ballot1), f"SCPBallot(counter=1, value={self.value1})")
+

--- a/src/SCPPrepare.py
+++ b/src/SCPPrepare.py
@@ -1,0 +1,15 @@
+from typing import Optional
+from SCPBallot import SCPBallot
+
+class SCPPrepare:
+    def __init__(self, ballot: SCPBallot, prepared: Optional[SCPBallot] = None,
+                 aCounter: int = 0, hCounter: int = 0, cCounter: int = 0):
+        self.ballot = ballot
+        self.prepared = prepared
+        self.aCounter = aCounter
+        self.hCounter = hCounter
+        self.cCounter = cCounter
+
+    def __repr__(self):
+        return (f"SCPPrepare(ballot={self.ballot}, prepared={self.prepared}, "
+                f"aCounter={self.aCounter}, hCounter={self.hCounter}, cCounter={self.cCounter})")

--- a/src/SCPPrepare_test.py
+++ b/src/SCPPrepare_test.py
@@ -1,0 +1,25 @@
+import unittest
+from Transaction import Transaction
+from State import State
+from Value import Value
+from SCPBallot import SCPBallot
+from SCPPrepare import SCPPrepare
+
+class SCPPrepare_test(unittest.TestCase):
+    def setUp(self):
+        transactions = [Transaction(time=1.0)]
+        state = State.init
+        value = Value(transactions=transactions, state=state)
+        self.ballot = SCPBallot(counter=1, value=value)
+        self.prepared = SCPBallot(counter=2, value=value)
+        self.scp_prepare = SCPPrepare(ballot=self.ballot, prepared=self.prepared, aCounter=1, hCounter=2, cCounter=1)
+
+    def test_scp_prepare_initialization(self):
+        self.assertEqual(self.scp_prepare.ballot, self.ballot)
+        self.assertEqual(self.scp_prepare.prepared, self.prepared)
+        self.assertEqual(self.scp_prepare.aCounter, 1)
+        self.assertEqual(self.scp_prepare.hCounter, 2)
+        self.assertEqual(self.scp_prepare.cCounter, 1)
+
+    def test_scp_prepare_repr(self):
+        self.assertEqual(repr(self.scp_prepare), f"SCPPrepare(ballot={self.ballot}, prepared={self.prepared}, aCounter=1, hCounter=2, cCounter=1)")

--- a/src/Transaction.py
+++ b/src/Transaction.py
@@ -14,10 +14,9 @@ from Log import log
 import random
 
 class Transaction():
-
     def __init__(self,time=None):
         self._hash = '%x' % random.getrandbits(32)
-        self._time = time
+        self._time = time if time is not None else time.time()
         log.transaction.info('Created transaction with hash %s and time %s', self._hash,self._time)
 
     def __repr__(self):


### PR DESCRIPTION
Added SCPBallot and  SCPPrepare as due to the reference document:

struct SCPBallot {
    uint32_t counter; // n
    Value value;      // x
};

struct SCPPrepare {
    SCPBallot ballot;        // current & highest prepare vote
    SCPBallot* prepared;     // highest accepted prepared ballot
    uint32_t aCounter;       // lowest non-aborted ballot counter or 0
    uint32_t hCounter;       // h.counter or 0 if h == NULL
    uint32_t cCounter;       // c.counter or 0 if !c || !hCounter
};