### PR TITLE
Add data structures & functions for SCPPrepare implementation in Node.py & add logs in SCPPrepare and SCPBallot

### DIFF
--- a/src/Node_test.py
+++ b/src/Node_test.py
@@ -646,3 +646,64 @@ class NodeTest(unittest.TestCase):
         self.assertTrue(self.node.nomination_state['voted'] == [])
         self.assertTrue(self.node.nomination_state['accepted'] == [value3])
         self.assertTrue(len(self.node.nomination_state['accepted']) == 1)
+
+    def test_retrieved_confirmed_values(self):
+        self.node = Node(name="1")
+        value1 = Value(transactions={Transaction(0), Transaction(0)})
+        value2 = Value(transactions={Transaction(0)})
+        value3 = Value(transactions={Transaction(0)})
+        self.node.nomination_state['confirmed'] = [value1, value2, value3]
+        self.node.prepared_ballots = {
+            value1: {'aCounter': 1, 'cCounter': 1, 'hCounter': 1,
+                                                         'highestCounter': 1},
+            value2: {'aCounter': 2, 'cCounter': 2, 'hCounter': 2,
+                                                         'highestCounter': 2},
+        }
+
+        retrieved_value = self.node.retrieve_confirmed_value()
+        self.assertIsNotNone(retrieved_value)
+        self.assertIn(retrieved_value, self.node.nomination_state['confirmed'])
+
+    def test_retrieved_confirmed_values_returns_None_for_empty(self):
+        self.node = Node(name="1")
+        self.node.nomination_state['confirmed'] = []
+
+        retrieved_value = self.node.retrieve_confirmed_value()
+        self.assertIsNone(retrieved_value)
+
+    def test_get_prepared_ballot_counters(self):
+        self.node = Node(name="1")
+        value1 = Value(transactions={Transaction(0), Transaction(0)})
+        value2 = Value(transactions={Transaction(0)})
+
+        self.node.prepared_ballots = {
+            value1: {'aCounter': 1, 'cCounter': 1, 'hCounter': 1, 'highestCounter': 1},
+            value2: {'aCounter': 2, 'cCounter': 2, 'hCounter': 2, 'highestCounter': 2},
+        }
+
+        state_val1 = self.node.get_prepared_ballot_counters(value1)
+        self.assertIsNotNone(state_val1)
+        self.assertEqual(state_val1['aCounter'], 1)
+        self.assertEqual(state_val1['cCounter'], 1)
+        self.assertEqual(state_val1['hCounter'], 1)
+
+        state_val2 = self.node.get_prepared_ballot_counters(value2)
+        self.assertIsNotNone(state_val2)
+        self.assertEqual(state_val2['aCounter'], 2)
+        self.assertEqual(state_val2['cCounter'], 2)
+        self.assertEqual(state_val2['hCounter'], 2)
+
+        self.assertNotEqual(state_val1, state_val2)
+
+    def test_get_prepared_ballot_counters_returns_None_for_empty(self):
+        self.node = Node(name="1")
+        value1 = Value(transactions={Transaction(0), Transaction(0)})
+        value2 = Value(transactions={Transaction(0)})
+
+        self.node.prepared_ballots = {
+            value1: {'aCounter': 1, 'cCounter': 1, 'hCounter': 1, 'highestCounter': 1},
+        }
+
+        state_val2 = self.node.get_prepared_ballot_counters(value2)
+        self.assertIsNone(state_val2)
+

--- a/src/SCPBallot.py
+++ b/src/SCPBallot.py
@@ -1,9 +1,12 @@
 from Value import Value
+from Log import log
 
 class SCPBallot:
     def __init__(self, counter: int, value: Value):
         self.counter = counter
         self.value = value
+        log.value.info('Created value, hash = %s, state = %s, transactions = %s', self.counter, self.value,)
+
 
     def __lt__(self, other):
         if self.counter != other.counter:

--- a/src/SCPPrepare.py
+++ b/src/SCPPrepare.py
@@ -1,5 +1,6 @@
 from typing import Optional
 from SCPBallot import SCPBallot
+from Log import log
 
 class SCPPrepare:
     def __init__(self, ballot: SCPBallot, prepared: Optional[SCPBallot] = None,
@@ -9,6 +10,7 @@ class SCPPrepare:
         self.aCounter = aCounter
         self.hCounter = hCounter
         self.cCounter = cCounter
+        log.message.info('Created SCPPrepare message, data = %s', self)
 
     def __repr__(self):
         return (f"SCPPrepare(ballot={self.ballot}, prepared={self.prepared}, "


### PR DESCRIPTION
Added structures to Node.py:
1. balloting_state - Keeps state of Ballots in 'voted', 'accepted', 'confirmed' and 'aborted' states.
2. ballot_statement_counter - a statement_counter to be used for Quorum checks.
3. ballot_prepare_broadcast_flags - might have to be removed later, this is to flag prepared messages. Maybe this will be updated by other nodes who are broadcasting SCPPrepare messages, or the current node will add its broadcast SCPPrepare messages there.
4. prepared_ballots - Keeps track of the prepared ballots & the counters. This will be used when creating a new ballot for a repeating Value or when creating a ballot for a new Value.

2 Functions have also been added in Node.py. These are: retrieve_confirmed_value - retrieves a confirmed value from nomination_state. This will be used to create ballots

get_prepared_ballot_counters - retrieves the values of all counters for a ballot, given a Value as input. Will be used when making values

Also added logs to SCPPrepare and SCPBallot classes
