### PR TITLE
This commit adds the function to prepare an SCPPrepare message in Nod…

### DIFF
--- a/src/FBAConsensus.py
+++ b/src/FBAConsensus.py
@@ -3,8 +3,8 @@
 FBAConsensus
 =========================
 
-Author: Matija Piskorec
-Last update: August 2023
+Author: Matija Piskorec, Jaime de Vivero Woods
+Last update: August 2024
 
 Federated Byzantine Agreement (FBA) consensus class.
 """
@@ -24,7 +24,8 @@ class FBAConsensus:
         events = [Event('mine'),
                   Event('retrieve_transaction_from_mempool'),
                   Event('nominate'),
-                  Event('retrieve_message_from_peer')]
+                  Event('retrieve_message_from_peer'),
+                  Event('prepare_ballot_msg')]
 
         # # TODO: Remove gossip event from the consensus!
         # Event('gossip'),

--- a/src/Node_test.py
+++ b/src/Node_test.py
@@ -4,6 +4,8 @@ from Log import log
 import unittest
 from Value import Value
 from SCPNominate import SCPNominate
+from SCPBallot import SCPBallot
+from SCPPrepare import SCPPrepare
 from Storage import Storage
 from Node import Node
 from Transaction import Transaction
@@ -706,4 +708,60 @@ class NodeTest(unittest.TestCase):
 
         state_val2 = self.node.get_prepared_ballot_counters(value2)
         self.assertIsNone(state_val2)
+
+    def test_prepare_ballot_msg(self):
+        self.node = Node(name="1")
+        confirmed_value = Value(transactions={Transaction(0), Transaction(0)})
+        self.node.nomination_state['confirmed'] = [confirmed_value]
+
+        self.node.prepare_ballot_msg()
+        # Ensure the message was prepared
+        self.assertEqual(len(self.node.ballot_prepare_broadcast_flags), 1)
+        prepared_msg = self.node.ballot_prepare_broadcast_flags.pop()
+        self.assertIsInstance(prepared_msg, SCPPrepare)
+
+    def test_prepare_ballot_msg_for_no_confirmed_values(self):
+        self.node = Node(name="1")
+        self.node.nomination_state['confirmed'] = []
+        self.node.retrieve_confirmed_value = MagicMock(return_value=None)
+
+        self.node.prepare_ballot_msg()
+        self.node.retrieve_confirmed_value.assert_not_called()
+        self.assertEqual(len(self.node.ballot_prepare_broadcast_flags), 0)
+
+    def test_prepare_ballot_msg_for_existing_voted_value(self):
+        self.node = Node(name="1")
+        confirmed_value = Value(transactions={Transaction(0)})
+        self.node.nomination_state['confirmed'] = [confirmed_value]
+
+        # Mock Functions
+        self.node.retrieve_confirmed_value = MagicMock(return_value=confirmed_value)
+        self.node.get_prepared_ballot_counters = MagicMock(return_value={'aCounter': 1, 'cCounter': 1, 'hCounter': 1})
+
+        self.node.balloting_state['aborted'] = {}
+        self.node.balloting_state['voted'][confirmed_value.hash] = SCPBallot(counter=1, value=confirmed_value)
+
+        self.node.prepare_ballot_msg()
+        # Ensure the message was prepared
+        self.assertEqual(len(self.node.ballot_prepare_broadcast_flags), 1)
+
+        prepared_msg = self.node.ballot_prepare_broadcast_flags.pop()
+        self.assertIsInstance(prepared_msg, SCPPrepare)
+        self.assertEqual(prepared_msg.ballot.counter, 2)  # Incremented counter for existing voted value
+
+    def test_prepare_ballot_msg_for_no_aborted_value(self):
+        self.node = Node(name="1")
+        confirmed_value = Value(transactions={Transaction(0)})
+        self.node.nomination_state['confirmed'] = [confirmed_value]
+        self.node.balloting_state['aborted'][confirmed_value.hash] = SCPBallot(counter=1, value=confirmed_value)
+
+        self.node.get_prepared_ballot_counters = MagicMock(return_value=None)
+
+        self.node.prepare_ballot_msg()
+        # get_prepared_ballot_counters is the first function to be called if the value is not in the aborted field so we check if it gets called, it should NOT
+        self.node.get_prepared_ballot_counters.assert_not_called()
+        self.assertEqual(len(self.node.ballot_prepare_broadcast_flags), 0)
+
+
+
 

--- a/src/Simulator.py
+++ b/src/Simulator.py
@@ -4,7 +4,7 @@ Simulator
 ================================================
 
 Author: Matija Piskorec, Jaime de Vivero Woods
-Last update: July 2023
+Last update: August 2024
 
 The following class contains command line (CLI) interface for the Stellar Consensus Protocol (SCP) simulator.
 
@@ -111,7 +111,10 @@ class Simulator:
                              'nominate':{'tau':3.0,
                                        'tau_domain':self._nodes},
                              'retrieve_message_from_peer':{'tau':3.0,
-                                       'tau_domain':self._nodes}}
+                                       'tau_domain':self._nodes},
+                             'prepare_ballot_msg': {'tau': 2.0,
+                                                            'tau_domain': self._nodes}
+                             }
 
         # ALL SIMULATION EVENTS COULD OCCUR AT ANY POINT, WHEN WE IMPLEMENT BALLOTING WE'LL HAVE TO
         # DISABLE NOMINATE
@@ -183,6 +186,10 @@ class Simulator:
 
                 random_node = np.random.choice(self._nodes)
                 random_node.receive_message()
+
+            case 'prepare_ballot_msg':
+                random_node = np.random.choice(self._nodes)
+                random_node.prepare_ballot_msg()
 
 
 if __name__=='__main__':


### PR DESCRIPTION
Adds prepare SCPPrepare message to Protocol.

The changes affect:

Node.py: 'prepare_ballot_msg' is defined which retrieves a confirmed message from the node's nomination state and makes an SCPPrepare message from it. It then adds it to its state and broadcast flag for SCPPrepare phase. This is also logged.

FBAConsensus.py: Added the 'prepare_ballot_msg' event to the Simulator.

Simulator.py: Added the 'prepare_ballot_msg' event