### PR TITLE
This commits adds the prepare SCPCommit functionalitz

### DIFF
--- a/src/FBAConsensus.py
+++ b/src/FBAConsensus.py
@@ -3,8 +3,8 @@
 FBAConsensus
 =========================
 
-Author: Matija Piskorec
-Last update: August 2023
+Author: Matija Piskorec, Jaime de Vivero Woods
+Last update: December 2024
 
 Federated Byzantine Agreement (FBA) consensus class.
 """
@@ -26,7 +26,8 @@ class FBAConsensus:
                   Event('nominate'),
                   Event('retrieve_message_from_peer'),
                   Event('prepare_ballot'),
-                  Event('receive_prepare_message')]
+                  Event('receive_prepare_message'),
+                  Event('prepare_commit')]
 
         # # TODO: Remove gossip event from the consensus!
         # Event('gossip'),

--- a/src/SCPCommit.py
+++ b/src/SCPCommit.py
@@ -1,7 +1,7 @@
 from SCPBallot import SCPBallot
 
 class SCPCommit:
-    def __init__(self, ballot: SCPBallot, preparedCounter: int, hCounter: int, cCounter: int):
+    def __init__(self, ballot: SCPBallot, preparedCounter: int, hCounter: int = 0, cCounter: int = 0):
         self.ballot = ballot
         self.preparedCounter = preparedCounter # This is the counter of the highest accepted prepared ballot--maintained identically to the "prepared" field in the PREPARE phase. Since the "value" field will always be the same as "ballot", only the counter is sent in the COMMIT phase
         self.hCounter = hCounter

--- a/src/SCPPrepare.py
+++ b/src/SCPPrepare.py
@@ -2,8 +2,7 @@ from typing import Optional
 from SCPBallot import SCPBallot
 
 class SCPPrepare:
-    def __init__(self, ballot: SCPBallot, prepared: Optional[SCPBallot] = None,
-                 aCounter: int = 0, hCounter: int = 0, cCounter: int = 0):
+    def __init__(self, ballot: SCPBallot, prepared: Optional[SCPBallot] = None, aCounter: int = 0, hCounter: int = 0, cCounter: int = 0):
         self.ballot = ballot
         self.prepared = prepared
         self.aCounter = aCounter

--- a/src/Simulator.py
+++ b/src/Simulator.py
@@ -4,7 +4,7 @@ Simulator
 ================================================
 
 Author: Matija Piskorec, Jaime de Vivero Woods
-Last update: July 2023
+Last update: December 2024
 
 The following class contains command line (CLI) interface for the Stellar Consensus Protocol (SCP) simulator.
 
@@ -115,7 +115,9 @@ class Simulator:
                              'prepare_ballot': {'tau':7.0,
                                        'tau_domain':self._nodes},
                              'receive_prepare_message': {'tau':1.0,
-                                       'tau_domain':self._nodes}
+                                       'tau_domain':self._nodes},
+                             'prepare_commit': {'tau':3.0,
+                                       'tau_domain':self._nodes},
                              }
 
         # ALL SIMULATION EVENTS COULD OCCUR AT ANY POINT, WHEN WE IMPLEMENT BALLOTING WE'LL HAVE TO
@@ -195,6 +197,10 @@ class Simulator:
             case 'receive_prepare_message':
                 random_node = np.random.choice(self._nodes)
                 random_node.receive_prepare_message()
+
+            case 'prepare_commit':
+                random_node = np.random.choice(self._nodes)
+                random_node.prepare_SCPCommit_msg()
 
 
 if __name__=='__main__':


### PR DESCRIPTION
The retrieve_confirmed_prepare_ballot retrieves a confirmed SCPPrepare message from a peer from the node's QuorumSet.

The 'prepare_SCPCommit_msg' retrieves a confirmed SCPPrepare message, checks if it is not None, initalises an SCPCommit message, and adds to its broadcast flag for peers to retrieve in later functionality to be implemented.

The Simulator and FBAConsensus classes have been edited to add this event