### PR TITLE
This commits adds functionality to process & check Quorum threshold f…

### DIFF
--- a/src/Node_test.py
+++ b/src/Node_test.py
@@ -1364,3 +1364,154 @@ class NodeTest(unittest.TestCase):
         self.assertEqual(len(self.node.ballot_prepare_broadcast_flags), 0)
 
 
+
+
+
+    def test_process_commit_ballot_message_works_for_case1(self):
+        self.node = Node(name="1")
+        self.sender_node = Node(name='2')
+
+        value1 = Value(transactions={Transaction(0), Transaction(0)})
+        ballot = SCPBallot(counter=1, value=value1)
+
+        self.node.commit_ballot_state['voted'][value1.hash] = ballot
+        mock_ballot = SCPBallot(counter=2, value=value1)
+        mock_msg = SCPCommit(ballot=mock_ballot, preparedCounter=mock_ballot.counter)
+
+        self.node.process_commit_ballot_message(mock_msg, self.sender_node)
+
+        self.assertIn(ballot.value.hash, self.node.commit_ballot_state['voted'])
+        self.assertEqual(self.node.commit_ballot_state['voted'][value1.hash], mock_ballot)
+        self.assertIn(self.sender_node, self.node.commit_ballot_statement_counter[value1]['voted'])
+
+    def test_process_commit_ballot_message_works_for_case2(self):
+        self.node = Node(name="1")
+        self.sender_node = Node(name='2')
+        value1 = Value(transactions={Transaction(0), Transaction(0)})
+        value2 = Value(transactions={Transaction(0)})
+
+        ballot1 = SCPBallot(counter=1, value=value1)
+
+        self.node.commit_ballot_state['voted'][value1.hash] = ballot1
+
+        mock_ballot = SCPBallot(counter=2, value=value2)
+        mock_msg = SCPCommit(ballot=mock_ballot, preparedCounter=mock_ballot.counter)
+
+        self.node.process_commit_ballot_message(mock_msg, self.sender_node)
+
+        self.assertIn(ballot1.value.hash, self.node.commit_ballot_state['voted'])
+        self.assertEqual(self.node.commit_ballot_state['voted'][value2.hash], mock_ballot)
+        self.assertEqual(self.node.commit_ballot_state['voted'][value1.hash], ballot1)
+        self.assertIn(self.sender_node, self.node.commit_ballot_statement_counter[value2]['voted'])
+
+    def test_process_commit_ballot_message_works_for_case3(self):
+        self.node = Node(name="1")
+        value1 = Value(transactions={Transaction(0), Transaction(0)})
+        self.sender_node = Node(name='2')
+
+        smaller_ballot1 = SCPBallot(counter=2, value=value1)
+        larger_ballot2 = SCPBallot(counter=3, value=value1)
+
+        self.node.commit_ballot_state['voted'][value1.hash] = larger_ballot2
+
+        mock_msg = SCPCommit(ballot=smaller_ballot1, preparedCounter=smaller_ballot1.counter)
+
+        self.node.process_commit_ballot_message(mock_msg, self.sender_node)
+
+        self.assertIn(larger_ballot2.value.hash, self.node.commit_ballot_state['voted'])
+        self.assertEqual(self.node.commit_ballot_state['voted'][value1.hash].counter, larger_ballot2.counter)
+        self.assertNotEqual(self.node.commit_ballot_state['voted'][value1.hash].counter, smaller_ballot1.counter)
+        self.assertIn(self.sender_node, self.node.commit_ballot_statement_counter[value1]['voted'])
+
+    def test_commit_quorum_threshold_node_itself_signed_message(self):
+        node2 = Node("test_node2")
+        self.node = Node(name="Node1")
+        self.node.quorum_set.set(nodes=node2, inner_sets=[])
+
+        value = Value(transactions={Transaction(0), Transaction(0)})
+        ballot = SCPBallot(counter=1, value=value)
+
+        # Mock nomination_state and statement_counter
+        self.node.commit_ballot_state = {
+            "voted": {value.hash: ballot},
+            "accepted": {},
+            "confirmed": {},
+            "aborted": {}
+        }
+
+        self.node.commit_ballot_statement_counter = {
+            value: {
+                "voted": set(),  # Node1 itself has voted for the value
+                "accepted": set(),
+                "confirmed": set(),
+                "aborted": set()
+            }
+        }
+        self.node.commit_ballot_statement_counter[value]["voted"].add(node2)
+
+        result = self.node.check_Commit_Quorum_threshold(ballot)
+        self.assertTrue(result)
+
+    def test_commit_quorum_threshold_not_met(self):
+        self.node = Node(name="Node1")
+
+        value = Value(transactions={Transaction(0), Transaction(0)})
+        ballot = SCPBallot(counter=1, value=value)
+
+
+        # Mock balloting_state and ballot statement_counter
+        self.node.commit_ballot_state = {
+            "voted": {},
+            "accepted": {},
+            "confirmed": {}
+        }
+
+        self.node.commit_ballot_statement_counter = {
+            value.hash: {
+                "voted": {},
+                "accepted": {}
+            }
+        }
+
+        result = self.node.check_Commit_Quorum_threshold(ballot=ballot)
+        self.assertFalse(result)
+
+
+    def test_commit_quorum_threshold_met_for_inner_sets(self):
+        node2 = Node("test_node2")
+        node3 = Node("test_node3")
+        node4 = Node("test_node4")
+        node5 = Node("test_node5")
+        self.node = Node(name="Node1")
+
+        self.node.quorum_set.set(nodes=[node2, node3], inner_sets=[[node3, node4], [node4, node5]])
+
+        value = Value(transactions={Transaction(0), Transaction(0)})
+        value2 = Value(transactions={Transaction(0), Transaction(0)})
+        ballot = SCPBallot(counter=1, value=value)
+        ballot2 = SCPBallot(counter=1, value=value2)
+
+        # Mock nomination_state and statement_counter
+        self.node.commit_ballot_state = {
+            "voted": {value.hash: {ballot}},
+            "accepted": {value2.hash : {ballot2}},
+            "confirmed": {}
+        }
+        # This will look like: self.balloting_state = {'voted': {'value_hash_1': SCPBallot(counter=1, value=ValueObject1),},'accepted': { 'value_hash_2': SCPBallot(counter=3, value=ValueObject2)},'confirmed': { ... },'aborted': { ... }}
+        # This will use sets for node names as opposed to counts, so will look like: {SCPBallot1.value: {'voted': set(Node1), ‘accepted’: set(Node2, Node3), ‘confirmed’: set(), ‘aborted’: set(), SCPBallot2.value: {'voted': set(), ‘accepted’: set(), ‘confirmed’: set(), ‘aborted’: set(node1, node2, node3)}
+
+        # [ballot.value] = {'voted': set(), 'accepted': set(), 'confirmed': set(), 'aborted': set()}
+        self.node.commit_ballot_statement_counter = {
+            value: {
+                "voted": set(),
+                "accepted": set()
+            }
+        }
+        self.node.commit_ballot_statement_counter[value]["voted"].add(node2)
+        self.node.commit_ballot_statement_counter[value]["voted"].add(node3)
+        self.node.commit_ballot_statement_counter[value]["voted"].add(node4)
+        self.node.commit_ballot_statement_counter[value]["accepted"].add(node4)
+        self.node.commit_ballot_statement_counter[value]["accepted"].add(node5)
+
+        result = self.node.check_Commit_Quorum_threshold(ballot)
+        self.assertTrue(result)

--- a/src/QuorumSet.py
+++ b/src/QuorumSet.py
@@ -112,6 +112,24 @@ class QuorumSet():
         else:
             return False
 
+    def check_commit_threshold(self, ballot, quorum, threshold, commit_statement_counter):
+        signed_counter = 0
+        seen = set()
+        if ballot.value not in commit_statement_counter:
+            return False
+
+        # For the ballot provided, iterate over voted, accepted & if counts meet threshold return True
+        for state in ('voted', 'accepted'):
+            for node in commit_statement_counter[ballot.value].get(state, set()):
+                if node in quorum and node not in seen:
+                    seen.add(node)
+                    signed_counter += 1
+
+        if signed_counter >= threshold:
+            return True
+        else:
+            return False
+
     def check_inner_set_blocking_threshold(self, calling_node, val, quorum):
         # Check if any node in the Quorum has issued message "m" - not including the node itself
         count = 0


### PR DESCRIPTION
This commit adds functionality to process & check Quorum Threshold of SCPCommit messages

The 'process_commit_ballot_message' processes an SCPCommit message and adds it to the relevant state keeping track of votes

The 'check_Commit_Quorum_threshold' checks for Quorum Threshold of an SCPCommit ballot for 'voted' or 'accepted'.

These functions will later be used to update the states of SCPCommit ballots and move to the Externalise phase