### PR TITLE
This commits adds functionality to prepare SCPExternalize messages after SCPCommit phase ends 

### DIFF
--- a/src/FBAConsensus.py
+++ b/src/FBAConsensus.py
@@ -28,7 +28,8 @@ class FBAConsensus:
                   Event('prepare_ballot'),
                   Event('receive_prepare_message'),
                   Event('prepare_commit'),
-                  Event('receive_commit_message')]
+                  Event('receive_commit_message'),
+                  Event('prepare_externalize_message')]
 
         # # TODO: Remove gossip event from the consensus!
         # Event('gossip'),

--- a/src/Node.py
+++ b/src/Node.py
@@ -22,6 +22,7 @@ from SCPNominate import SCPNominate
 from SCPBallot import SCPBallot
 from SCPPrepare import SCPPrepare
 from SCPCommit import SCPCommit
+from SCPExternalize import SCPExternalize
 from Value import Value
 from Storage import Storage
 from Globals import Globals
@@ -80,6 +81,12 @@ class Node():
         self.received_commit_ballot_broadcast_msgs = {}
         self.committed_ballots = {} # This looks like: self.prepared_ballots[ballot.value] = SCPPrepare('aCounter': aCounter,'cCounter': cCounter,'hCounter': hCounter,'highestCounter': ballot.counter)
 
+        ###################################
+        # EXTERNALIZE PHASE STRUCTURES    #
+        ###################################
+        self.externalize_broadcast_flags = set()
+        self.externalized_slot_counter = set()
+        self.peer_externalised_statements = {} # This will be used to track finalised slots for nodes, so will look like: {Node1: set(SCPExternalize(ballot, 1), SCPExternalize(ballot2, 3), Node2:{})}
 
         # TODO: Implement the logic for advancing the nomination rounds each n+1 seconds!
 
@@ -525,31 +532,33 @@ class Node():
             ballot = SCPBallot(counter=1, value=confirmed_val)
             log.node.info('Node %s created SCPBallot: %s', self.name, ballot.value)
 
+        if not self.check_if_finalised(ballot):
+            # Get counters for new SCPPrepare message
+            prepare_msg_counters = self.get_prepared_ballot_counters(confirmed_val)
+            if prepare_msg_counters is not None:
+                prepare_msg = SCPPrepare(ballot=ballot, aCounter=prepare_msg_counters.aCounter, cCounter=prepare_msg_counters.cCounter, hCounter=prepare_msg_counters.hCounter)
+                log.node.info('Node %s has increased counter on prepared SCPPrepare message with ballot %s, h_counter=%d, a_counter=%d, c_counter=%d.',self.name, confirmed_val, prepare_msg_counters.aCounter, prepare_msg_counters.cCounter,prepare_msg_counters.hCounter)
+                self.ballot_prepare_broadcast_flags.add(prepare_msg)
+                self.prepared_ballots[ballot.value] = prepare_msg
+                if ballot.value not in self.ballot_statement_counter:
+                    self.ballot_statement_counter[ballot.value] = {'voted': set(), 'accepted': set(), 'confirmed':set(), 'aborted':set()}
+                    self.ballot_statement_counter[ballot.value]['voted'] = set()
+                    self.ballot_statement_counter[ballot.value]['voted'].add(self)
+            else:
+                # If prepare_msg_counters is none then there are no counters for this value and we have to set the defaults
+                prepare_msg = SCPPrepare(ballot=ballot)
+                self.ballot_prepare_broadcast_flags.add(prepare_msg)
+                self.prepared_ballots[ballot.value] = prepare_msg
+                self.balloting_state['voted'][confirmed_val.hash] = ballot
+                if ballot.value not in self.ballot_statement_counter:
+                    self.ballot_statement_counter[ballot.value] = {'voted': set(), 'accepted': set(), 'confirmed':set(), 'aborted':set()}
+                    self.ballot_statement_counter[ballot.value]['voted'] = set()
+                    self.ballot_statement_counter[ballot.value]['voted'].add(self)
+                log.node.info('Node %s has prepared SCPPrepare message with ballot %s, h_counter=%d, a_counter=%d, c_counter=%d.', self.name, confirmed_val, 0, 0,0)
 
-        # Get counters for new SCPPrepare message
-        prepare_msg_counters = self.get_prepared_ballot_counters(confirmed_val)
-        if prepare_msg_counters is not None:
-            prepare_msg = SCPPrepare(ballot=ballot, aCounter=prepare_msg_counters.aCounter, cCounter=prepare_msg_counters.cCounter, hCounter=prepare_msg_counters.hCounter)
-            log.node.info('Node %s has increased counter on prepared SCPPrepare message with ballot %s, h_counter=%d, a_counter=%d, c_counter=%d.',self.name, confirmed_val, prepare_msg_counters.aCounter, prepare_msg_counters.cCounter,prepare_msg_counters.hCounter)
-            self.ballot_prepare_broadcast_flags.add(prepare_msg)
-            self.prepared_ballots[ballot.value] = prepare_msg
-            if ballot.value not in self.ballot_statement_counter:
-                self.ballot_statement_counter[ballot.value] = {'voted': set(), 'accepted': set(), 'confirmed':set(), 'aborted':set()}
-                self.ballot_statement_counter[ballot.value]['voted'] = set()
-                self.ballot_statement_counter[ballot.value]['voted'].add(self)
+            log.node.info('Node %s appended SCPPrepare message to its storage and state, message = %s', self.name, prepare_msg)
         else:
-            # If prepare_msg_counters is none then there are no counters for this value and we have to set the defaults
-            prepare_msg = SCPPrepare(ballot=ballot)
-            self.ballot_prepare_broadcast_flags.add(prepare_msg)
-            self.prepared_ballots[ballot.value] = prepare_msg
-            self.balloting_state['voted'][confirmed_val.hash] = ballot
-            if ballot.value not in self.ballot_statement_counter:
-                self.ballot_statement_counter[ballot.value] = {'voted': set(), 'accepted': set(), 'confirmed':set(), 'aborted':set()}
-                self.ballot_statement_counter[ballot.value]['voted'] = set()
-                self.ballot_statement_counter[ballot.value]['voted'].add(self)
-            log.node.info('Node %s has prepared SCPPrepare message with ballot %s, h_counter=%d, a_counter=%d, c_counter=%d.', self.name, confirmed_val, 0, 0,0)
-
-        log.node.info('Node %s appended SCPPrepare message to its storage and state, message = %s', self.name, prepare_msg)
+            log.node.info('Node %s has not prepared SCPPrepare message as the ballot %s has already been finalised', self.name, ballot)
 
     def process_prepare_ballot_message(self, message, sender):
         received_ballot = message.ballot
@@ -716,7 +725,7 @@ class Node():
             if sending_node != self and not None:
                 message = self.retrieve_ballot_prepare_message(sending_node)
 
-                if message is not None:
+                if message is not None and not self.check_if_finalised(message.ballot):
                     self.process_prepare_ballot_message(message, sending_node)
                     log.node.info('Node %s retrieving messages from his peer Node %s!', self.name,sending_node.name)
                     ballot = message.ballot # message[0] is voted field
@@ -728,7 +737,6 @@ class Node():
 
                         log.node.info('Quorum threshold met for accepted ballot %s at Node %s', ballot, self.name)
                         self.update_prepare_balloting_state(ballot, "accepted")
-
                 else:
                     log.node.info('Node %s has no SCPPrepare messages to retrieve from neighbor Node %s!', self.name, sending_node.name)
         else:
@@ -913,3 +921,36 @@ class Node():
                     log.node.info('Node %s has no SCPCommit messages to retrieve from neighbor Node %s!', self.name, sending_node.name)
         else:
             log.node.info('Node %s could not retrieve peer!', self.name)
+
+    def retrieve_confirmed_commit_ballot(self):
+        if len(self.commit_ballot_state['confirmed']) > 0:
+            # random_ballot_hash = np.random.choice(self.balloting_state['confirmed'])
+            random_ballot_hash = np.random.choice(list(self.commit_ballot_state['confirmed'].keys()))
+            confirmed_commit_ballot = self.commit_ballot_state['confirmed'][random_ballot_hash]  # Take a random Value from the confirmed state
+            log.node.info('Node %s retrieved confirmed commit ballot %s for SCPExternalize', self.name, confirmed_commit_ballot)
+            return confirmed_commit_ballot
+        else:
+            log.node.info('Node %s has no confirmed commit ballots to use for SCPExternalize!', self.name)
+            return None
+
+    def check_if_finalised(self, ballot):
+        for externalize_msg in self.externalized_slot_counter:
+            if externalize_msg.ballot == ballot:
+                return True
+        return False
+
+    def prepare_Externalize_msg(self):
+        """
+        Prepare SCPExternalize message for Externalize phase
+        """
+        if len(self.commit_ballot_state['confirmed']) == 0: # Check if there are any values to prepare
+            log.node.info('Node %s has no committed ballots to externalize.', self.name)
+            return
+
+        finalised_ballot = self.retrieve_confirmed_commit_ballot() # Retrieve a Value from the SCPPrepare 'confirmed' state
+        if finalised_ballot is not None:
+            externalize_msg = SCPExternalize(ballot=finalised_ballot, hCounter=finalised_ballot.counter)
+            self.externalize_broadcast_flags.add(externalize_msg)
+            self.externalized_slot_counter.add(externalize_msg)
+            log.node.info('Node %s appended SCPExternalize message to its storage and state, message = %s', self.name, externalize_msg)
+        log.node.info('Node %s could not retrieve a confirmed SCPCommit message from its peer!')

--- a/src/Node_test.py
+++ b/src/Node_test.py
@@ -7,6 +7,7 @@ from SCPNominate import SCPNominate
 from SCPPrepare import SCPPrepare
 from SCPBallot import SCPBallot
 from SCPCommit import SCPCommit
+from SCPExternalize import SCPExternalize
 from Storage import Storage
 from Node import Node
 from Transaction import Transaction
@@ -821,6 +822,20 @@ class NodeTest(unittest.TestCase):
         self.node.get_prepared_ballot_counters.assert_not_called()
         self.assertEqual(len(self.node.ballot_prepare_broadcast_flags), 0)
 
+    def test_prepare_ballot_msg_for_finalised_ballot(self):
+        self.node = Node(name="1")
+        confirmed_value = Value(transactions={Transaction(0)})
+        self.node.nomination_state['confirmed'] = [confirmed_value]
+        ballot = SCPBallot(value=confirmed_value, counter=0)
+        finalised_msg = SCPExternalize(ballot=ballot, hCounter=ballot.counter)
+        self.node.externalized_slot_counter.add(finalised_msg)
+
+        self.node.retrieve_confirmed_value = MagicMock(return_value=confirmed_value)
+        self.node.get_prepared_ballot_counters = MagicMock()
+
+        self.node.get_prepared_ballot_counters.assert_not_called()
+
+
     def test_process_prepare_ballot_message_works_for_case1(self):
         self.node = Node(name="1")
         self.sender_node = Node(name='2')
@@ -1325,6 +1340,28 @@ class NodeTest(unittest.TestCase):
         self.node.process_prepare_ballot_message.assert_called_with(message, self.sending_node)
         self.node.update_prepare_balloting_state.assert_called_with(ballot1, 'accepted')
 
+    def test_message_already_externalized(self):
+        # Mock the necessary attributes and methods
+        self.node = Node("test_node")
+        self.sending_node = Node("test2")
+        self.node.process_prepare_ballot_message = MagicMock()
+
+        value1 = Value(transactions={Transaction(0), Transaction(0)})
+        ballot1 = SCPBallot(value=value1, counter=0)
+        self.node.balloting_state = {'voted': {}, 'accepted': {value1.hash: ballot1}, 'confirmed': {}}
+
+        message = SCPPrepare(ballot=ballot1)
+        self.sending_node.storage.add_messages(message)
+
+        self.node.quorum_set.retrieve_random_peer = MagicMock(return_value=self.sending_node)
+        self.node.retrieve_ballot_prepare_message = MagicMock(return_value=message)
+
+        externalize_msg = SCPExternalize(ballot=ballot1, hCounter=ballot1.counter)
+        self.node.externalized_slot_counter.add(externalize_msg)  # MockBallot is already externalized
+
+        self.node.receive_prepare_message()
+        self.node.process_prepare_ballot_message.assert_not_called()
+
     def test_retrieved_confirmed_prepared_commit_values(self):
         self.node = Node(name="1")
         value1 = Value(transactions={Transaction(0), Transaction(0)})
@@ -1342,7 +1379,7 @@ class NodeTest(unittest.TestCase):
         retrieved_value = self.node.retrieve_confirmed_value()
         self.assertIsNone(retrieved_value)
 
-    def test_prepare_ballot_msg(self):
+    def test_prepare_commit_ballot_msg(self):
         self.node = Node(name="1")
         value1 = Value(transactions={Transaction(0), Transaction(0)})
         ballot1 = SCPBallot(counter=0, value=value1)
@@ -1354,17 +1391,14 @@ class NodeTest(unittest.TestCase):
         prepared_msg = self.node.commit_ballot_broadcast_flags.pop()
         self.assertIsInstance(prepared_msg, SCPCommit)
 
-    def test_prepare_ballot_msg_for_no_confirmed_values(self):
+    def test_prepare_commit_ballot_msg_for_no_confirmed_values(self):
         self.node = Node(name="1")
         self.node.balloting_state = {"voted": {}, "accepted": {}, "confirmed": {}}
         self.node.retrieve_confirmed_value = MagicMock(return_value=None)
 
-        self.node.prepare_ballot_msg()
+        self.node.prepare_SCPCommit_msg()
         self.node.retrieve_confirmed_value.assert_not_called()
         self.assertEqual(len(self.node.ballot_prepare_broadcast_flags), 0)
-
-
-
 
 
     def test_process_commit_ballot_message_works_for_case1(self):
@@ -1475,7 +1509,6 @@ class NodeTest(unittest.TestCase):
 
         result = self.node.check_Commit_Quorum_threshold(ballot=ballot)
         self.assertFalse(result)
-
 
     def test_commit_quorum_threshold_met_for_inner_sets(self):
         node2 = Node("test_node2")
@@ -1708,8 +1741,6 @@ class NodeTest(unittest.TestCase):
 
         self.assertEqual(retrieved, None)
 
-
-
     def test_receive_commit_message_processes_voted_to_accepted(self):
         self.node = Node("test_node")
         self.test_node = Node("test2")
@@ -1772,3 +1803,26 @@ class NodeTest(unittest.TestCase):
         # Assert that nomination state is updated when quorum threshold is met
         self.node.process_commit_ballot_message.assert_called_with(message, self.sending_node)
         self.node.update_commit_balloting_state.assert_called_with(ballot1, 'accepted')
+
+
+    def test_prepare_externalize_msg(self):
+        self.node = Node(name="1")
+        value1 = Value(transactions={Transaction(0), Transaction(0)})
+        ballot1 = SCPBallot(counter=0, value=value1)
+        self.node.commit_ballot_state = {"voted": {}, "accepted": {}, "confirmed": {value1.hash: ballot1}}
+
+        self.node.prepare_Externalize_msg()
+        # Ensure the message was prepared
+        self.assertEqual(len(self.node.externalize_broadcast_flags), 1)
+        self.assertEqual(len(self.node.externalized_slot_counter), 1)
+        prepared_msg = self.node.externalize_broadcast_flags.pop()
+        self.assertIsInstance(prepared_msg, SCPExternalize)
+
+    def test_prepare_externalize_msg_for_no_confirmed_values(self):
+        self.node = Node(name="1")
+        self.node.commit_ballot_state = {"voted": {}, "accepted": {}, "confirmed": {}}
+        self.node.retrieve_confirmed_commit_ballot = MagicMock(return_value=None)
+
+        self.node.prepare_Externalize_msg()
+        self.node.retrieve_confirmed_commit_ballot.assert_not_called()
+        self.assertEqual(len(self.node.externalize_broadcast_flags), 0)

--- a/src/SCPExternalize.py
+++ b/src/SCPExternalize.py
@@ -1,0 +1,9 @@
+from SCPBallot import SCPBallot
+
+class SCPExternalize:
+    def __init__(self, ballot: SCPBallot, hCounter: int = 0):
+        self.ballot = ballot
+        self.hCounter = hCounter
+
+    def __repr__(self):
+        return (f"SCPExternalize(ballot={self.ballot}, hCounter={self.hCounter})")

--- a/src/SCPExternalize_test.py
+++ b/src/SCPExternalize_test.py
@@ -1,0 +1,25 @@
+import unittest
+from SCPBallot import SCPBallot
+from SCPExternalize import SCPExternalize
+from Transaction import Transaction
+from Value import Value
+from State import State
+
+class SCPExternalizeTest(unittest.TestCase):
+    def setUp(self):
+        transactions = [Transaction(0)]
+        state = State.init
+        value = Value(transactions=transactions, state=state)
+        self.ballot = SCPBallot(counter=1, value=value)
+        self.scp_externalize = SCPExternalize(ballot=self.ballot, hCounter=5)
+
+    def test_scp_externalize_initialization(self):
+        self.assertEqual(self.scp_externalize.ballot, self.ballot)
+        self.assertEqual(self.scp_externalize.hCounter, 5)
+
+    def test_scp_externalize_default_hCounter(self):
+        scp_externalize_default = SCPExternalize(ballot=self.ballot)
+        self.assertEqual(scp_externalize_default.hCounter, 0)
+
+    def test_scp_externalize_repr(self):
+        self.assertEqual(repr(self.scp_externalize),f"SCPExternalize(ballot={self.ballot}, hCounter=5)")

--- a/src/Simulator.py
+++ b/src/Simulator.py
@@ -119,6 +119,8 @@ class Simulator:
                              'prepare_commit': {'tau':7.0,
                                        'tau_domain':self._nodes},
                              'receive_commit_message': {'tau':1.0,
+                                       'tau_domain':self._nodes},
+                             'prepare_externalize_message': {'tau': 3.0,
                                        'tau_domain':self._nodes}
                              }
 
@@ -207,6 +209,10 @@ class Simulator:
             case 'receive_commit_message':
                 random_node = np.random.choice(self._nodes)
                 random_node.receive_commit_message()
+
+            case 'prepare_externalize_message':
+                random_node = np.random.choice(self._nodes)
+                random_node.prepare_Externalize_msg()
 
 
 if __name__=='__main__':


### PR DESCRIPTION
The 'prepare_Externalize_msg' retrieves a confirmed commit ballot, creates an SCPExternalize message and stores it in its state and broadcast flag for peers.

The functions to receive and prepare ballots in the Prepare phase have also been edited to check if ballots have been finalised, before they are prepared. This is to ensure the Externalize phase is being used by nodes to track finalised slots.